### PR TITLE
Replacing deprecated `mcrypt_encrypt` with `openssl_encrypt`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         }
     },
     "require": {
+        "ext-openssl": "*",
         "omnipay/common": "~3.0"
     },
     "require-dev": {

--- a/src/SporoPay/Sign/Des3Sign.php
+++ b/src/SporoPay/Sign/Des3Sign.php
@@ -7,7 +7,7 @@ class Des3Sign
     public function sign($input, $secret)
     {
         $signature = null;
-        
+
         $bytesHash = sha1($input, true);
 
         while (strlen($bytesHash) < 24) {
@@ -22,9 +22,9 @@ class Des3Sign
         $iv .= $iv; // 4
         $iv .= $iv; // 8
 
-        $signatureBytes = mcrypt_encrypt(MCRYPT_TRIPLEDES, $key, $bytesHash, MCRYPT_MODE_CBC, $iv);
+        $signatureBytes = @openssl_encrypt($bytesHash, "DES-EDE3-CBC", $key, OPENSSL_RAW_DATA | OPENSSL_NO_PADDING, $iv);
         $signature = base64_encode($signatureBytes);
-        
+
         return $signature;
     }
 }


### PR DESCRIPTION
`mcrypt_encrypt` was deprecated in PHP 7.1 and isn't distributed
with PHP 7.2+ anymore by default. The replacement library to use
is openssl. See following for more info:

https://www.php.net/manual/en/migration71.deprecated.php

I'm not sure right now whether this is a breaking change or not and whether the major version should be bumped as only the underlying PHP library changed. Keeping up to you.